### PR TITLE
Update rubocop.yml

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -118,3 +118,6 @@ Style/FrozenStringLiteralComment:
 # https://github.com/rubocop-hq/rubocop/blob/master/manual/cops_style.md#stylenumericliterals
 Style/NumericLiterals:
   Enabled: false
+
+Rails/HttpPositionalArguments:
+  Enabled: false


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/0.49.1/RuboCop/Cop/Rails/HttpPositionalArguments

I think we need to turn this off for rails 5.

```
spec/controllers/api/v1/document_types_controller_spec.rb:135:9: C: Rails/HttpPositionalArguments: Use keyword arguments instead of positional arguments for http call: delete. 
        delete :destroy, params(:id => doc_type.id, :format => :json) 
        ^^^^^^ 
spec/controllers/api/v1/document_types_controller_spec.rb:144:9: C: Rails/HttpPositionalArguments: Use keyword arguments instead of positional arguments for http call: delete. 
        delete :destroy, params(:id => doc_type.id, :format => :json) 
        ^^^^^^ 
```

I'm honestly not even sure if this is the right keywording. #hackathon